### PR TITLE
Use LINE Messaging API SDK for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - **メール解析**: S3 に保存されたメールファイルを取得・解析
 - **LLM による情報抽出**: Bedrock 経由で LLM を呼び出し、メール本文からイベント情報を抽出
 - **Google カレンダー登録**: 抽出したイベント情報を一括で Google カレンダーに登録
-- **LINE 通知**: 登録結果（成功/失敗の件数と詳細）を LINE に通知
+- **LINE 通知**: 登録結果（成功/失敗の件数と詳細）を LINE Messaging API SDK で通知
 
 ## アーキテクチャ
 
@@ -31,7 +31,7 @@
 - LangChain（LLM インターフェース）
 - Amazon Bedrock（LLM プロバイダー）
 - Google Calendar API（カレンダー登録）
-- LINE Message API（登録通知）
+- LINE Messaging API SDK（登録通知）
 
 
 ### アーキテクチャ図

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "google-auth>=2.35.0,<3.0.0",
     "google-api-python-client>=2.132.0,<3.0.0",
     "langchain>=1.2.3,<1.3.0",
-    "langchain-aws>=1.2.0,<1.3.0"
+    "langchain-aws>=1.2.0,<1.3.0",
+    "line-bot-sdk>=3.12.0,<4.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Motivation
- Replace low-level HTTP calls with the official SDK to simplify LINE notification integration and error handling.
- Update documentation to reflect the switch to the LINE Messaging API SDK.
- Add the SDK as a project dependency so deployments use the supported client library.

### Description
- Replaced the `httpx`-based push implementation with `line-bot-sdk` v3 usage in `push_message` by calling `MessagingApi.push_message` via `ApiClient` and `Configuration`.
- Switched error handling to catch `ApiException` and parse the error body to produce `LineApiError` messages.
- Updated the `timeout` parameter type to `float | None` and removed the custom `create_sync_client` / direct endpoint usage.
- Updated `README.md` to mention the `LINE Messaging API SDK` and added `line-bot-sdk` to `pyproject.toml` dependencies.

### Testing
- No automated tests were run as part of this change.
- Please run `pytest`, for example to exercise `app/tests/calendar_auto_register/features/line_notify_post/test_line_notify_post.py`, to validate the integration with the new SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964806d3b248330bfd1b9640b57cc7f)