### PR TITLE
Set Lambda timeout to 120 seconds only

### DIFF
--- a/infra/sam/template.yaml
+++ b/infra/sam/template.yaml
@@ -22,7 +22,7 @@ Parameters:
 
 Globals:
   Function:
-    Timeout: 30
+    Timeout: 120
     MemorySize: 1024
     Tracing: Active
 


### PR DESCRIPTION
### Motivation
- Allow longer-running Lambda executions by increasing the default function timeout to 120 seconds.
- Preserve existing API Gateway behavior by not changing proxy integrations or stage settings.
- Revert the explicit OpenAPI `DefinitionBody` and related permission changes so only the timeout is modified.
- Keep logging and method settings unchanged to avoid deployment behavioral changes.

### Description
- Update `Globals.Function.Timeout` from `30` to `120` in `infra/sam/template.yaml`.
- Restore the function `Events` (`ApiRoot`, `ApiProxy`) and the original `CalendarApi` properties instead of using an explicit `DefinitionBody` OpenAPI integration.
- Remove the previously introduced `CalendarApiInvokePermission` / OpenAPI integration changes so the only net change is the timeout.
- No other resource properties, policies, or settings were modified.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696693fbaccc8330ae18b3715e62c7fa)