### PR TITLE
chore: Bedrock モデルを Haiku 4.5（JP）に変更 & LINE Webhook を SFN 直接呼び出しに移行

### DIFF
--- a/.steering/20260212-line-webhook-implementation/design.md
+++ b/.steering/20260212-line-webhook-implementation/design.md
@@ -31,7 +31,7 @@
 
 - **Lambdalith** = 単一 Lambda が全 API ルートを処理（FastAPI + Mangum）。ビジネスロジックの単位は HTTP エンドポイント
 - **SFN** = オーケストレーター。各ステップを HTTP Task で Lambdalith の API を順番に呼ぶ
-- **EventBridge** = SFN の起動トリガー（S3 Event / LINE Webhook からの putEvents）
+- **EventBridge** = SFN の起動トリガー（S3 Event → Mail SM のみ）
 - **Python 関数直接呼び出しによるオーケストレーションは行わない**。各ステップは API を経由する
 
 ### 1.2 メール処理フロー
@@ -56,11 +56,9 @@ LINE Platform
 API Gateway → Lambda（Lambdalith）
   ↓ [Layer 1] HMAC-SHA256 署名検証 → NG: 403
   ↓ [Layer 2] userId allowlist 検証 → NG: スキップ（200 OK）
-  ↓ EventBridge.putEvents（LINE イベント詳細を乗せる）
-  ↓ 200 OK ← LINE Platform に即返却（5 秒制約を解消）
+  ↓ SFN.StartExecution(name=message_id)  ← 重複排除: 同一 message_id は ExecutionAlreadyExists で無視
+  ↓ 200 OK ← LINE Platform に即返却
 
-EventBridge
-  ↓ Rule: source=calendar-auto-register.line → StartExecution
 LINE State Machine (Step Functions)
   → Choice: message.type?
       text  → POST /llm/extract-event        （text → events）
@@ -68,6 +66,11 @@ LINE State Machine (Step Functions)
   → POST /calendar/events
   → POST /line/notify
 ```
+
+> **設計変更（2026-06-17）**: 当初は EvB.putEvents → EventBridge Rule → SFN の間接起動だったが、
+> Lambda コールドスタートで LINE Platform がリトライし同一 message_id が二重起動する問題が判明。
+> Lambda から SFN を直接 `StartExecution(name=message_id)` で起動する方式に変更。
+> EventBridge の LINE Rule は不要となり削除。
 
 ### 1.4 実装アプローチ（TDD）
 
@@ -157,7 +160,7 @@ async def line_webhook_post(request: Request) -> dict:
     # 4. パース
     webhook_request = LineWebhookRequest(**json.loads(body))
 
-    # 5. [Layer 2] userId チェック + EventBridge.putEvents
+    # 5. [Layer 2] userId チェック + SFN.StartExecution
     process_webhook(webhook_request, settings=settings)
 
     # 6. 200 OK（即返却）
@@ -166,7 +169,7 @@ async def line_webhook_post(request: Request) -> dict:
 
 ```python
 def process_webhook(request: LineWebhookRequest, *, settings: Settings) -> None:
-    """userId 検証 + EventBridge.putEvents。LLM/Calendar/LINE 通知はここでは行わない。"""
+    """userId 検証 + SFN.StartExecution(name=message_id)。LLM/Calendar/LINE 通知はここでは行わない。"""
     for event in request.events:
         if event.type != "message" or event.message is None:
             continue
@@ -177,24 +180,29 @@ def process_webhook(request: LineWebhookRequest, *, settings: Settings) -> None:
             logger.warning("未認可 userId: %s", event.source.userId)
             continue
 
-        _put_line_event(event, settings=settings)
+        _start_line_sm(event, settings=settings)
 
 
-def _put_line_event(event: LineWebhookEvent, *, settings: Settings) -> None:
-    """EventBridge に LINE イベントを発行する。"""
+def _start_line_sm(event: LineWebhookEvent, *, settings: Settings) -> None:
+    """LINE SM を message_id を実行名として直接起動する。"""
     import boto3, json
-    client = boto3.client("events", region_name=settings.region)
-    client.put_events(Entries=[{
-        "Source": "calendar-auto-register.line",
-        "DetailType": "LineMessageEvent",
-        "Detail": json.dumps({
-            "message_type": event.message.type,
-            "message_id": event.message.id,
-            "text": event.message.text,
-            "user_id": event.source.userId,
-        }),
-        "EventBusName": "default",
-    }])
+    from botocore.exceptions import ClientError
+    client = boto3.client("stepfunctions", region_name=settings.region)
+    try:
+        client.start_execution(
+            stateMachineArn=settings.line_sm_arn,
+            name=event.message.id,  # LINE message_id = 実行名 → 重複排除
+            input=json.dumps({"detail": {
+                "message_type": event.message.type,
+                "message_id": event.message.id,
+                "text": event.message.text,
+                "user_id": event.source.userId,
+            }}),
+        )
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ExecutionAlreadyExists":
+            return  # LINE リトライによる重複を無視
+        raise
 ```
 
 ---
@@ -211,7 +219,7 @@ def _put_line_event(event: LineWebhookEvent, *, settings: Settings) -> None:
 [Layer 2] source.userId allowlist 検証 (usecase 層)
   allowlist_line_user_ids に含まれない userId のイベントをスキップ。
   LINE URL・Channel Secret 流出時の不正利用を防止。
-  → NG: 200 OK（LINE 要件を満たす）+ WARNING ログ + putEvents スキップ
+  → NG: 200 OK（LINE 要件を満たす）+ WARNING ログ + StartExecution スキップ
 ```
 
 ### 3.2 SFN → API Gateway 認証
@@ -381,7 +389,7 @@ API Key は SFN の State 定義の Parameters に SecureString 参照で設定�
 | D7 | `_run_extraction_chain()` で LangChain チェーン共通化 | メール・LINE テキストで同一チェーンを共有 |
 | D8 | SFN = オーケストレーター、EvB = トリガー | Python 関数直接呼び出しによるオーケストレーションを排除。各ステップが独立した HTTP API として存在することで単体テスト・再実行が容易 |
 | D9 | `POST /llm/extract-event` をテキスト/メール共通化 | `text` 必須、メールコンテキストは任意。LINE テキスト・メールで分岐 |
-| D10 | `POST /line/webhook` は EvB.putEvents のみ | LINE の 5 秒応答制約を解決。LLM/Calendar/通知は SFN が非同期で処理 |
+| D10 | `POST /line/webhook` は SFN.StartExecution(name=message_id) のみ | LINE コールドスタートリトライによる二重起動を排除。ExecutionAlreadyExists で同一 message_id を自動スキップ。LLM/Calendar/通知は SFN が非同期で処理 |
 | D11 | 2 つの SM（Mail SM / LINE SM）を別々に定義 | 入力スキーマが根本的に異なる。フローが独立して読みやすい |
 
 ---
@@ -441,11 +449,11 @@ LineStateMachine:
 ### 6.2 Lambda IAM 追加
 
 ```yaml
-# Lambda が EventBridge に putEvents できるよう追加
+# Lambda が LINE SM を直接起動できるよう追加（重複排除: name=message_id）
 - Statement:
     Effect: Allow
-    Action: "events:PutEvents"
-    Resource: "arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default"
+    Action: "states:StartExecution"
+    Resource: !Ref LineStateMachine
 
 # Bedrock: Vision モデル追加
 - Statement:
@@ -476,7 +484,7 @@ LineStateMachine:
 | テスト対象 | 確認内容 |
 |---|---|
 | `verify_line_signature()` | 正常/不正署名 |
-| `process_webhook()` | userId check + putEvents 呼び出し |
+| `process_webhook()` | userId check + StartExecution(name=message_id) 呼び出し |
 | `POST /line/webhook` router | 署名 NG→403、secret 未設定→500、正常→200 |
 | `POST /llm/extract-event` | text のみ→raw text パス、mail フィールドあり→mail パス |
 | `POST /llm/extract-event-image` | message_id → LINE DL → Bedrock → events |
@@ -485,9 +493,9 @@ LineStateMachine:
 
 | シナリオ | 期待結果 |
 |---|---|
-| 正常テキスト Webhook | 200 OK + putEvents 呼び出し |
-| 正常画像 Webhook | 200 OK + putEvents 呼び出し |
+| 正常テキスト Webhook | 200 OK + StartExecution 呼び出し |
+| 正常画像 Webhook | 200 OK + StartExecution 呼び出し |
 | 署名検証失敗 | 403 |
-| 未認可 userId | 200 OK（putEvents されない）|
+| 未認可 userId | 200 OK（StartExecution されない）|
 | events 空配列 | 200 OK |
 | LINE_CHANNEL_SECRET 未設定 | 500 |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | `POST /llm/extract-event-image` | LINE 画像メッセージ（message_id）から Bedrock Vision でイベント抽出 |
 | `POST /calendar/events` | 抽出したイベントを Google カレンダーに一括登録 |
 | `POST /line/notify` | 登録結果を LINE Push で通知 |
-| `POST /line/webhook` | LINE Webhook 受信（HMAC 検証 + EventBridge putEvents のみ） |
+| `POST /line/webhook` | LINE Webhook 受信（HMAC 検証 + SFN 直接起動、message_id を実行名に使用） |
 
 ### アーキテクチャ図
 ![architecture.png](docs/architecture.png)
@@ -82,10 +82,7 @@ LINE User
     │ POST /line/webhook
     ▼
 API Gateway → Lambda（HMAC 検証 + userId 確認）
-    │ putEvents
-    ▼
-EventBridge（LINE Rule）
-    │ StartExecution
+    │ StartExecution(name=message_id)  ← message_id を実行名にして重複排除
     ▼
 Step Functions（LINE SM）
     │
@@ -97,7 +94,9 @@ Step Functions（LINE SM）
     └─ POST /line/notify            LINE に結果を通知
 ```
 
-> LINE Webhook は LINE Platform の 5 秒制約があるため、`POST /line/webhook` は EventBridge への `putEvents` のみ実施して即時 200 OK を返す。LLM 処理・カレンダー登録・通知は SFN が非同期で担う。
+> LINE Platform のコールドスタートによるリトライで同一メッセージが2回届くことがある。
+> `POST /line/webhook` は `message_id` を SFN 実行名として直接 `StartExecution` を呼ぶことで、
+> 2回目の呼び出しは `ExecutionAlreadyExists` となり自動排除される。
 
 ---
 
@@ -121,7 +120,7 @@ EventBridge（S3 Object Created）→ Mail SM 起動
 
 #### LINE SM（LINE メッセージ処理）
 
-EventBridge（LINE Webhook → putEvents）→ LINE SM 起動
+Lambda（`/line/webhook`）→ LINE SM 直接起動（`name=message_id`）
 
 ```
 [CheckMessageType]        message_type で分岐
@@ -134,7 +133,7 @@ EventBridge（LINE Webhook → putEvents）→ LINE SM 起動
          [POST /line/notify]       LINE に結果を通知
 ```
 
-※ LINE Webhook は LINE Platform の 5 秒制約を解決するため、`POST /line/webhook` は EventBridge への putEvents のみ実施し、即時 200 OK を返す。LLM 処理・カレンダー登録・通知はすべて SFN が非同期で処理する。
+※ LINE Webhook は `message_id` を SFN 実行名として直接 `StartExecution` を呼び、即時 200 OK を返す。LLM 処理・カレンダー登録・通知はすべて SFN が非同期で処理する。LINE Platform のリトライで同一 `message_id` が再送された場合は `ExecutionAlreadyExists` で自動排除される。
 
 ※この SFN を使ったオーケストレーション構成はあくまで検証のため本アプリケーションレベルだと過剰設計であり、単一の Lambda 関数で完結させるのが本来は望ましい。
 

--- a/app/src/calendar_auto_register/core/settings.py
+++ b/app/src/calendar_auto_register/core/settings.py
@@ -30,6 +30,7 @@ class Settings:
     api_key: str | None
     line_channel_secret: str | None  # Layer 1: Webhook 署名検証用
     allowlist_line_user_ids: list[str]  # Layer 2: 送信者制限用
+    line_sm_arn: str | None
 
     @property
     def is_local(self) -> bool:
@@ -115,4 +116,5 @@ def load_settings() -> Settings:
         api_key=os.getenv("API_KEY"),
         line_channel_secret=os.getenv("LINE_CHANNEL_SECRET"),
         allowlist_line_user_ids=_load_json_list(os.getenv("ALLOWLIST_LINE_USER_IDS")),
+        line_sm_arn=os.getenv("LINE_SM_ARN"),
     )

--- a/app/src/calendar_auto_register/features/line_webhook/usecase_line_webhook_post.py
+++ b/app/src/calendar_auto_register/features/line_webhook/usecase_line_webhook_post.py
@@ -1,7 +1,11 @@
 """LINE Webhook ユースケース。
 
-[D8, D10] このモジュールは EventBridge.putEvents のみを実行する。
+[D8, D10] このモジュールは SFN.start_execution のみを実行する。
 LLM 抽出・カレンダー登録・LINE 通知は Step Functions がオーケストレートする。
+
+[Dedup] message_id を SFN 実行名に使用することで、LINE Platform のリトライによる
+多重起動を防ぐ。同一 message_id での 2 回目の start_execution は
+ExecutionAlreadyExists で無害に終了する。
 """
 
 from __future__ import annotations
@@ -10,6 +14,7 @@ import json
 import logging
 
 import boto3
+from botocore.exceptions import ClientError
 
 from calendar_auto_register.core.settings import Settings
 from calendar_auto_register.features.line_webhook.schemas_line_webhook_post import (
@@ -18,10 +23,6 @@ from calendar_auto_register.features.line_webhook.schemas_line_webhook_post impo
 )
 
 logger = logging.getLogger(__name__)
-
-# EventBridge に送信するソース識別子
-_EVENT_SOURCE = "calendar-auto-register.line"
-_EVENT_DETAIL_TYPE = "LineMessageEvent"
 
 # SFN の Choice ステートで処理できるメッセージタイプ
 _SUPPORTED_MESSAGE_TYPES = frozenset({"text", "image"})
@@ -37,7 +38,8 @@ def process_webhook(
     メッセージイベントのみを対象に、以下を実行:
       1. [Layer 2] source.userId allowlist 検証
       2. サポートされるメッセージタイプ（text/image）の確認
-      3. EventBridge.putEvents でイベントを発行（非同期処理は SFN が担当）
+      3. SFN.start_execution でパイプラインを起動（非同期処理は SFN が担当）
+         実行名に message_id を使用し、LINE リトライによる多重起動を防ぐ。
 
     Args:
         request: LINE Webhook リクエスト
@@ -65,42 +67,53 @@ def process_webhook(
             )
             continue
 
-        _put_line_event(event, settings=settings)
+        _start_line_sm(event, settings=settings)
 
 
-def _put_line_event(
+def _start_line_sm(
     event: LineWebhookEvent,
     *,
     settings: Settings,
 ) -> None:
-    """EventBridge に LINE イベントを発行する。
+    """LINE SM を message_id を実行名として直接起動する。
 
-    SFN の LINE State Machine がこのイベントをトリガーとして起動し、
-    LLM 抽出・カレンダー登録・LINE 通知を HTTP Task で順番に処理する。
+    LINE Platform は応答が遅延すると同一イベントをリトライするが、
+    SFN は同名実行が存在する場合 ExecutionAlreadyExists を返すため、
+    重複起動を自動的に排除できる。
     """
     assert event.message is not None
+    assert settings.line_sm_arn, "LINE_SM_ARN が未設定です"
 
-    client = boto3.client("events", region_name=settings.region)
-    client.put_events(
-        Entries=[
-            {
-                "Source": _EVENT_SOURCE,
-                "DetailType": _EVENT_DETAIL_TYPE,
-                "Detail": json.dumps(
-                    {
-                        "message_type": event.message.type,
-                        "message_id": event.message.id,
-                        "text": event.message.text,
-                        "user_id": event.source.userId,
-                    }
-                ),
-                "EventBusName": "default",
+    # LINE SM は EventBridge 経由時と同じ $.detail.* 形式を期待する
+    sfn_input = json.dumps(
+        {
+            "detail": {
+                "message_type": event.message.type,
+                "message_id": event.message.id,
+                "text": event.message.text,
+                "user_id": event.source.userId,
             }
-        ]
+        }
     )
-    logger.info(
-        "EventBridge にイベントを発行: userId=%s, messageType=%s, messageId=%s",
-        event.source.userId,
-        event.message.type,
-        event.message.id,
-    )
+
+    client = boto3.client("stepfunctions", region_name=settings.region)
+    try:
+        client.start_execution(
+            stateMachineArn=settings.line_sm_arn,
+            name=event.message.id,
+            input=sfn_input,
+        )
+        logger.info(
+            "LINE SM を起動: userId=%s, messageType=%s, messageId=%s",
+            event.source.userId,
+            event.message.type,
+            event.message.id,
+        )
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ExecutionAlreadyExists":
+            logger.info(
+                "重複リクエストをスキップ（LINE リトライ）: messageId=%s",
+                event.message.id,
+            )
+            return
+        raise

--- a/app/tests/calendar_auto_register/features/line_webhook/test_router_line_webhook_post.py
+++ b/app/tests/calendar_auto_register/features/line_webhook/test_router_line_webhook_post.py
@@ -1,7 +1,7 @@
 """LINE Webhook ルーターのテスト（unit + integration）。
 
-[D10] usecase が EvB.putEvents のみになったため、
-E2E テストは boto3.client().put_events をモックして検証する。
+[D10] usecase が SFN.start_execution のみになったため、
+E2E テストは boto3.client().start_execution をモックして検証する。
 """
 
 from __future__ import annotations
@@ -178,18 +178,21 @@ def test_正常署名_process_webhookが呼ばれる() -> None:
     mock_process.assert_called_once()
 
 
-# ===== E2E 統合テスト（D10: usecase は putEvents のみ） =====
+_LINE_SM_ARN = "arn:aws:states:ap-northeast-1:123456789012:stateMachine:calendar-auto-register-line-sm"
+
+# ===== E2E 統合テスト（D10: usecase は start_execution のみ） =====
 
 def test_E2E_テキストメッセージ完全フロー() -> None:
-    """テキストメッセージの完全フロー: Webhook → putEvents → 200。
+    """テキストメッセージの完全フロー: Webhook → start_execution → 200。
 
-    [D10] usecase は EventBridge.putEvents のみを実行する。
+    [D10] usecase は SFN.start_execution のみを実行する。
     LLM/Calendar/通知は SFN が非同期で処理する。
     """
     import os
     secret = "test_channel_secret"
     os.environ["LINE_CHANNEL_SECRET"] = secret
-    os.environ.pop("ALLOWLIST_LINE_USER_IDS", None)  # CI環境の残留値をクリア
+    os.environ["LINE_SM_ARN"] = _LINE_SM_ARN
+    os.environ.pop("ALLOWLIST_LINE_USER_IDS", None)
     from calendar_auto_register.core.settings import load_settings
     load_settings.cache_clear()
 
@@ -197,8 +200,8 @@ def test_E2E_テキストメッセージ完全フロー() -> None:
     body = json.dumps(payload).encode("utf-8")
     signature = _make_signature(body, secret)
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         client = TestClient(create_app())
         res = client.post(
             "/line/webhook",
@@ -210,18 +213,19 @@ def test_E2E_テキストメッセージ完全フロー() -> None:
         )
 
     assert res.status_code == 200
-    mock_events_client.put_events.assert_called_once()
-    entries = mock_events_client.put_events.call_args.kwargs["Entries"]
-    detail = json.loads(entries[0]["Detail"])
+    mock_sfn.start_execution.assert_called_once()
+    kwargs = mock_sfn.start_execution.call_args.kwargs
+    detail = json.loads(kwargs["input"])["detail"]
     assert detail["message_type"] == "text"
 
 
-def test_E2E_画像メッセージ_putEventsが呼ばれる() -> None:
-    """画像メッセージの完全フロー: Webhook → putEvents → 200。"""
+def test_E2E_画像メッセージ_start_executionが呼ばれる() -> None:
+    """画像メッセージの完全フロー: Webhook → start_execution → 200。"""
     import os
     secret = "test_channel_secret"
     os.environ["LINE_CHANNEL_SECRET"] = secret
-    os.environ.pop("ALLOWLIST_LINE_USER_IDS", None)  # CI環境の残留値をクリア
+    os.environ["LINE_SM_ARN"] = _LINE_SM_ARN
+    os.environ.pop("ALLOWLIST_LINE_USER_IDS", None)
     from calendar_auto_register.core.settings import load_settings
     load_settings.cache_clear()
 
@@ -229,8 +233,8 @@ def test_E2E_画像メッセージ_putEventsが呼ばれる() -> None:
     body = json.dumps(payload).encode("utf-8")
     signature = _make_signature(body, secret)
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         client = TestClient(create_app())
         res = client.post(
             "/line/webhook",
@@ -242,19 +246,21 @@ def test_E2E_画像メッセージ_putEventsが呼ばれる() -> None:
         )
 
     assert res.status_code == 200
-    mock_events_client.put_events.assert_called_once()
-    entries = mock_events_client.put_events.call_args.kwargs["Entries"]
-    detail = json.loads(entries[0]["Detail"])
+    mock_sfn.start_execution.assert_called_once()
+    kwargs = mock_sfn.start_execution.call_args.kwargs
+    assert kwargs["name"] == "img-123"
+    detail = json.loads(kwargs["input"])["detail"]
     assert detail["message_type"] == "image"
     assert detail["message_id"] == "img-123"
 
 
-def test_E2E_未認可userId_200でputEventsなし() -> None:
-    """[D6] 未認可 userId → 200 OK（putEvents が呼ばれない）。"""
+def test_E2E_未認可userId_200でstart_executionなし() -> None:
+    """[D6] 未認可 userId → 200 OK（start_execution が呼ばれない）。"""
     import os
     import json as json_module
     secret = "test_channel_secret"
     os.environ["LINE_CHANNEL_SECRET"] = secret
+    os.environ["LINE_SM_ARN"] = _LINE_SM_ARN
     os.environ["ALLOWLIST_LINE_USER_IDS"] = json_module.dumps(["Uallowed"])
     from calendar_auto_register.core.settings import load_settings
     load_settings.cache_clear()
@@ -263,8 +269,8 @@ def test_E2E_未認可userId_200でputEventsなし() -> None:
     body = json.dumps(payload).encode("utf-8")
     signature = _make_signature(body, secret)
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         client = TestClient(create_app())
         res = client.post(
             "/line/webhook",
@@ -276,16 +282,17 @@ def test_E2E_未認可userId_200でputEventsなし() -> None:
         )
 
     assert res.status_code == 200
-    mock_events_client.put_events.assert_not_called()
+    mock_sfn.start_execution.assert_not_called()
 
     os.environ.pop("ALLOWLIST_LINE_USER_IDS", None)
 
 
-def test_E2E_空events_200でputEventsなし() -> None:
-    """events が空配列 → 200 OK（putEvents が呼ばれない）。"""
+def test_E2E_空events_200でstart_executionなし() -> None:
+    """events が空配列 → 200 OK（start_execution が呼ばれない）。"""
     import os
     secret = "test_channel_secret"
     os.environ["LINE_CHANNEL_SECRET"] = secret
+    os.environ["LINE_SM_ARN"] = _LINE_SM_ARN
     from calendar_auto_register.core.settings import load_settings
     load_settings.cache_clear()
 
@@ -293,8 +300,8 @@ def test_E2E_空events_200でputEventsなし() -> None:
     body = json.dumps(payload).encode("utf-8")
     signature = _make_signature(body, secret)
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         client = TestClient(create_app())
         res = client.post(
             "/line/webhook",
@@ -306,14 +313,15 @@ def test_E2E_空events_200でputEventsなし() -> None:
         )
 
     assert res.status_code == 200
-    mock_events_client.put_events.assert_not_called()
+    mock_sfn.start_execution.assert_not_called()
 
 
-def test_E2E_followイベント_200でputEventsなし() -> None:
-    """follow イベント → 200 OK（putEvents が呼ばれない）。"""
+def test_E2E_followイベント_200でstart_executionなし() -> None:
+    """follow イベント → 200 OK（start_execution が呼ばれない）。"""
     import os
     secret = "test_channel_secret"
     os.environ["LINE_CHANNEL_SECRET"] = secret
+    os.environ["LINE_SM_ARN"] = _LINE_SM_ARN
     from calendar_auto_register.core.settings import load_settings
     load_settings.cache_clear()
 
@@ -327,8 +335,8 @@ def test_E2E_followイベント_200でputEventsなし() -> None:
     body = json.dumps(payload).encode("utf-8")
     signature = _make_signature(body, secret)
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         client = TestClient(create_app())
         res = client.post(
             "/line/webhook",
@@ -340,23 +348,23 @@ def test_E2E_followイベント_200でputEventsなし() -> None:
         )
 
     assert res.status_code == 200
-    mock_events_client.put_events.assert_not_called()
+    mock_sfn.start_execution.assert_not_called()
 
 
 def test_E2E_署名失敗_403() -> None:
-    """[Layer 1] 署名失敗 → 403（putEvents が呼ばれない）。"""
+    """[Layer 1] 署名失敗 → 403（start_execution が呼ばれない）。"""
     import os
     os.environ["LINE_CHANNEL_SECRET"] = "correct_secret"
+    os.environ["LINE_SM_ARN"] = _LINE_SM_ARN
     from calendar_auto_register.core.settings import load_settings
     load_settings.cache_clear()
 
     payload = _webhook_payload(events=[_text_event()])
     body = json.dumps(payload).encode("utf-8")
-    # 間違ったシークレットで署名
     wrong_signature = _make_signature(body, "wrong_secret")
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         client = TestClient(create_app())
         res = client.post(
             "/line/webhook",
@@ -368,4 +376,4 @@ def test_E2E_署名失敗_403() -> None:
         )
 
     assert res.status_code == 403
-    mock_events_client.put_events.assert_not_called()
+    mock_sfn.start_execution.assert_not_called()

--- a/app/tests/calendar_auto_register/features/line_webhook/test_usecase_line_webhook_post.py
+++ b/app/tests/calendar_auto_register/features/line_webhook/test_usecase_line_webhook_post.py
@@ -1,15 +1,18 @@
 """LINE Webhook usecase のテスト。
 
-[D8, D10] usecase は EventBridge.putEvents のみを実行する。
+[D8, D10] usecase は SFN.start_execution のみを実行する。
 LLM/Calendar/通知は SFN が非同期でオーケストレートする。
+
+[Dedup] message_id を SFN 実行名に使うことで LINE リトライによる多重起動を防ぐ。
 """
 
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from calendar_auto_register.core.settings import Settings
 
@@ -18,8 +21,8 @@ def _make_settings(
     *,
     allowlist_line_user_ids: list[str] | None = None,
     region: str = "ap-northeast-1",
+    line_sm_arn: str = "arn:aws:states:ap-northeast-1:123456789012:stateMachine:calendar-auto-register-line-sm",
 ) -> Settings:
-    """テスト用 Settings を生成するヘルパー。"""
     from calendar_auto_register.core.settings import load_settings
     load_settings.cache_clear()
 
@@ -31,6 +34,7 @@ def _make_settings(
     os.environ["S3_RAW_MAIL_BUCKET"] = "test-bucket"
     os.environ["BEDROCK_MODEL_ID"] = "test-model"
     os.environ["AWS_DEFAULT_REGION"] = region
+    os.environ["LINE_SM_ARN"] = line_sm_arn
     if allowlist_line_user_ids is not None:
         os.environ["ALLOWLIST_LINE_USER_IDS"] = json.dumps(allowlist_line_user_ids)
     else:
@@ -44,7 +48,6 @@ def _make_text_event(
     text: str = "明日10時に会議があります",
     message_id: str = "msg-001",
 ):
-    """テキストメッセージイベントを生成するヘルパー。"""
     from calendar_auto_register.features.line_webhook.schemas_line_webhook_post import (
         LineMessage,
         LineSource,
@@ -63,7 +66,6 @@ def _make_image_event(
     user_id: str = "Uauthorized",
     message_id: str = "img-001",
 ):
-    """画像メッセージイベントを生成するヘルパー。"""
     from calendar_auto_register.features.line_webhook.schemas_line_webhook_post import (
         LineMessage,
         LineSource,
@@ -79,7 +81,6 @@ def _make_image_event(
 
 
 def _make_sticker_event(user_id: str = "Uauthorized"):
-    """sticker メッセージイベントを生成するヘルパー。"""
     from calendar_auto_register.features.line_webhook.schemas_line_webhook_post import (
         LineMessage,
         LineSource,
@@ -95,7 +96,6 @@ def _make_sticker_event(user_id: str = "Uauthorized"):
 
 
 def _make_follow_event(user_id: str = "Uauthorized"):
-    """follow イベントを生成するヘルパー。"""
     from calendar_auto_register.features.line_webhook.schemas_line_webhook_post import (
         LineSource,
         LineWebhookEvent,
@@ -109,20 +109,20 @@ def _make_follow_event(user_id: str = "Uauthorized"):
 
 
 def _make_webhook_request(events: list):
-    """LineWebhookRequest を生成するヘルパー。"""
     from calendar_auto_register.features.line_webhook.schemas_line_webhook_post import (
         LineWebhookRequest,
     )
     return LineWebhookRequest(destination="Udestination", events=events)
 
 
-# ===== 失敗系テスト（先に書く: D6, D10） =====
+def _make_client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": code}}, "StartExecution")
 
-def test_未認可userId_putEventsが呼ばれない() -> None:
-    """[D6] allowlist に含まれない userId の場合、putEvents が呼ばれないことを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
+
+# ===== スキップ系テスト =====
+
+def test_未認可userId_start_executionが呼ばれない() -> None:
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
 
     settings = _make_settings(allowlist_line_user_ids=["Uallowed"])
     webhook_request = _make_webhook_request([_make_text_event(user_id="Unotallowed")])
@@ -133,11 +133,8 @@ def test_未認可userId_putEventsが呼ばれない() -> None:
     mock_boto3.assert_not_called()
 
 
-def test_followイベント_putEventsが呼ばれない() -> None:
-    """message 以外のイベントタイプ（follow）の場合、putEvents が呼ばれないことを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
+def test_followイベント_start_executionが呼ばれない() -> None:
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
 
     settings = _make_settings()
     webhook_request = _make_webhook_request([_make_follow_event()])
@@ -148,11 +145,8 @@ def test_followイベント_putEventsが呼ばれない() -> None:
     mock_boto3.assert_not_called()
 
 
-def test_未対応メッセージタイプ_putEventsが呼ばれない() -> None:
-    """sticker 等の未対応メッセージタイプの場合、putEvents が呼ばれないことを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
+def test_未対応メッセージタイプ_start_executionが呼ばれない() -> None:
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
 
     settings = _make_settings()
     webhook_request = _make_webhook_request([_make_sticker_event()])
@@ -163,11 +157,8 @@ def test_未対応メッセージタイプ_putEventsが呼ばれない() -> None
     mock_boto3.assert_not_called()
 
 
-def test_空events_putEventsが呼ばれない() -> None:
-    """events が空リストの場合、putEvents が呼ばれないことを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
+def test_空events_start_executionが呼ばれない() -> None:
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
 
     settings = _make_settings()
     webhook_request = _make_webhook_request([])
@@ -178,122 +169,118 @@ def test_空events_putEventsが呼ばれない() -> None:
     mock_boto3.assert_not_called()
 
 
-# ===== 正常系テスト（D10: putEvents のみ） =====
+# ===== 正常系テスト =====
 
-def test_テキストメッセージ_putEventsが呼ばれる() -> None:
-    """[D10] テキストメッセージの場合、EventBridge.putEvents が呼ばれることを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
+def test_テキストメッセージ_start_executionが呼ばれる() -> None:
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
 
-    settings = _make_settings()
+    sm_arn = "arn:aws:states:ap-northeast-1:123:stateMachine:line-sm"
+    settings = _make_settings(line_sm_arn=sm_arn)
     text = "明日10時に会議があります"
     webhook_request = _make_webhook_request(
         [_make_text_event(user_id="Uuser", text=text, message_id="msg-001")]
     )
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         process_webhook(webhook_request, settings=settings)
 
-    mock_events_client.put_events.assert_called_once()
-    call_args = mock_events_client.put_events.call_args
-    entries = call_args.kwargs["Entries"]
-    assert len(entries) == 1
-    detail = json.loads(entries[0]["Detail"])
+    mock_sfn.start_execution.assert_called_once()
+    kwargs = mock_sfn.start_execution.call_args.kwargs
+    assert kwargs["stateMachineArn"] == sm_arn
+    assert kwargs["name"] == "msg-001"
+    detail = json.loads(kwargs["input"])["detail"]
     assert detail["message_type"] == "text"
     assert detail["message_id"] == "msg-001"
     assert detail["text"] == text
     assert detail["user_id"] == "Uuser"
 
 
-def test_画像メッセージ_putEventsが呼ばれる() -> None:
-    """[D10] 画像メッセージの場合、EventBridge.putEvents が呼ばれることを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
+def test_画像メッセージ_start_executionが呼ばれる() -> None:
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
 
-    settings = _make_settings()
+    sm_arn = "arn:aws:states:ap-northeast-1:123:stateMachine:line-sm"
+    settings = _make_settings(line_sm_arn=sm_arn)
     webhook_request = _make_webhook_request(
         [_make_image_event(user_id="Uuser", message_id="img-001")]
     )
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         process_webhook(webhook_request, settings=settings)
 
-    mock_events_client.put_events.assert_called_once()
-    call_args = mock_events_client.put_events.call_args
-    entries = call_args.kwargs["Entries"]
-    assert len(entries) == 1
-    detail = json.loads(entries[0]["Detail"])
+    mock_sfn.start_execution.assert_called_once()
+    kwargs = mock_sfn.start_execution.call_args.kwargs
+    assert kwargs["name"] == "img-001"
+    detail = json.loads(kwargs["input"])["detail"]
     assert detail["message_type"] == "image"
     assert detail["message_id"] == "img-001"
     assert detail["user_id"] == "Uuser"
 
 
-def test_putEventsのイベントソースとDetailType確認() -> None:
-    """EventBridge エントリの Source と DetailType が正しいことを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
+def test_空allowlist_全ユーザーにstart_executionが呼ばれる() -> None:
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
 
-    settings = _make_settings()
-    webhook_request = _make_webhook_request([_make_text_event()])
-
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
-        process_webhook(webhook_request, settings=settings)
-
-    entries = mock_events_client.put_events.call_args.kwargs["Entries"]
-    assert entries[0]["Source"] == "calendar-auto-register.line"
-    assert entries[0]["DetailType"] == "LineMessageEvent"
-
-
-def test_空allowlist_全ユーザーにputEventsが呼ばれる() -> None:
-    """[D6] allowlist が空のとき、全ユーザーに対して putEvents が呼ばれることを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
-
-    settings = _make_settings(allowlist_line_user_ids=[])  # 空リスト = 全許可
+    settings = _make_settings(allowlist_line_user_ids=[])
     webhook_request = _make_webhook_request([_make_text_event(user_id="Uanyone")])
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         process_webhook(webhook_request, settings=settings)
 
-    mock_events_client.put_events.assert_called_once()
+    mock_sfn.start_execution.assert_called_once()
 
 
-def test_認可userId_putEventsが呼ばれる() -> None:
-    """[D6] allowlist に含まれる userId の場合、putEvents が呼ばれることを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
+def test_認可userId_start_executionが呼ばれる() -> None:
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
 
     settings = _make_settings(allowlist_line_user_ids=["Uauthorized"])
     webhook_request = _make_webhook_request([_make_text_event(user_id="Uauthorized")])
 
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client):
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn):
         process_webhook(webhook_request, settings=settings)
 
-    mock_events_client.put_events.assert_called_once()
+    mock_sfn.start_execution.assert_called_once()
 
 
-def test_LLM呼び出しは行われない() -> None:
-    """[D10] process_webhook は LLM を呼び出さないことを確認する。"""
-    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import (
-        process_webhook,
-    )
+# ===== 冪等性テスト（Dedup） =====
+
+def test_重複messageId_ExecutionAlreadyExists_は正常終了() -> None:
+    """LINE リトライで同一 message_id が来た場合、例外を上げずに無視する。"""
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
+
+    settings = _make_settings()
+    webhook_request = _make_webhook_request([_make_text_event(message_id="dup-001")])
+
+    mock_sfn = MagicMock()
+    mock_sfn.start_execution.side_effect = _make_client_error("ExecutionAlreadyExists")
+    with patch("boto3.client", return_value=mock_sfn):
+        process_webhook(webhook_request, settings=settings)  # 例外が出ないこと
+
+
+def test_その他ClientError_は再送出される() -> None:
+    """ExecutionAlreadyExists 以外の ClientError は呼び出し元に伝播する。"""
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
 
     settings = _make_settings()
     webhook_request = _make_webhook_request([_make_text_event()])
 
-    # boto3 をモックしてputEventsを受け付ける
-    mock_events_client = MagicMock()
-    with patch("boto3.client", return_value=mock_events_client), \
+    mock_sfn = MagicMock()
+    mock_sfn.start_execution.side_effect = _make_client_error("AccessDeniedException")
+    with patch("boto3.client", return_value=mock_sfn):
+        with pytest.raises(ClientError):
+            process_webhook(webhook_request, settings=settings)
+
+
+def test_LLM呼び出しは行われない() -> None:
+    from calendar_auto_register.features.line_webhook.usecase_line_webhook_post import process_webhook
+
+    settings = _make_settings()
+    webhook_request = _make_webhook_request([_make_text_event()])
+
+    mock_sfn = MagicMock()
+    with patch("boto3.client", return_value=mock_sfn), \
          patch("calendar_auto_register.clients.bedrock_client.invoke_model") as mock_bedrock:
         process_webhook(webhook_request, settings=settings)
 

--- a/infra/sam/template.yaml
+++ b/infra/sam/template.yaml
@@ -44,6 +44,7 @@ Resources:
         Variables:
           APP_ENV: prod
           SSM_DOTENV_PARAMETER: !Ref SsmDotenvParameter
+          LINE_SM_ARN: !Ref LineStateMachine
       Policies:
         - AWSLambdaBasicExecutionRole
         - Statement:
@@ -55,8 +56,10 @@ Resources:
             Action:
               - "bedrock:InvokeModel"
             Resource:
-              # テキスト抽出モデル（メール・LINE テキスト共通）
-              - !Sub "arn:aws:bedrock:${AWS::Region}::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0"
+              # テキスト抽出モデル（メール・LINE テキスト共通）- JP クロスリージョン推論プロファイル
+              - !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/jp.anthropic.claude-haiku-4-5-20251001-v1:0"
+              - "arn:aws:bedrock:ap-northeast-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0"
+              - "arn:aws:bedrock:ap-northeast-3::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0"
         - Statement:
             Effect: Allow
             Action:
@@ -67,11 +70,11 @@ Resources:
             Effect: Allow
             Action: "s3:ListBucket"
             Resource: !Sub "arn:aws:s3:::${S3RawMailBucketName}"
-        # LINE Webhook: EventBridge にイベントを発行するための権限 [D10]
+        # LINE Webhook: LINE SM を直接起動するための権限 [Dedup: message_id を実行名に使用]
         - Statement:
             Effect: Allow
-            Action: "events:PutEvents"
-            Resource: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/default"
+            Action: "states:StartExecution"
+            Resource: !Ref LineStateMachine
       Events:
         ApiRoot:
           Type: Api
@@ -169,7 +172,6 @@ Resources:
                 Action: states:StartExecution
                 Resource:
                   - !Ref MailStateMachine
-                  - !Ref LineStateMachine
 
   # =========================================================
   # Step Functions: Mail State Machine
@@ -415,22 +417,6 @@ Resources:
                 "bucket": "<bucket>"
               }
 
-  # LINE Webhook → LINE State Machine
-  LineEventRule:
-    Type: AWS::Events::Rule
-    Properties:
-      Name: !Sub "${ProjectName}-line-sm"
-      Description: "LINE Webhook から発行されたイベントで LINE State Machine を起動する"
-      EventPattern:
-        source:
-          - calendar-auto-register.line
-      State: ENABLED
-      Targets:
-        - Id: LineStateMachineTarget
-          Arn: !Ref LineStateMachine
-          RoleArn: !GetAtt EvbToSfnRole.Arn
-          # InputTransformer なし: process_webhook が putEvents した Detail をそのまま SFN に渡す
-          # Detail: {"message_type": "text"|"image", "message_id": "...", "text": "...", "user_id": "..."}
 
 Outputs:
   CalendarFunctionArn:


### PR DESCRIPTION
## Summary

- **Bedrock モデル変更**: `anthropic.claude-3-5-sonnet-20240620-v1:0` → `jp.anthropic.claude-haiku-4-5-20251001-v1:0`（JP クロスリージョン推論プロファイル）
- **LINE Webhook**: EventBridge 経由 → SFN 直接呼び出し（`states:StartExecution`）に移行。`message_id` を実行名に使用して LINE リトライによる多重起動を防止
- **SAM テンプレート**: Bedrock IAM ポリシー更新（推論プロファイル + ベースモデル ARN 東京・大阪）、EventBridge ルール削除、`LINE_SM_ARN` 環境変数追加

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `infra/sam/template.yaml` | Bedrock IAM / Lambda 環境変数 / IAM EventBridge→SFN / LineEventRule 削除 |
| `core/settings.py` | `line_sm_arn` フィールド追加 |
| `usecase_line_webhook_post.py` | `_put_line_event` → `_start_line_sm` に変更 |
| テストファイル | SFN 呼び出しに合わせて更新 |

## Test plan

- [ ] `uv run --directory app pytest` — 80 tests GREEN 確認済み
- [ ] SAM デプロイ後、Lambda コンソールで Haiku 4.5 がレスポンスを返すことを確認
- [ ] LINE からメッセージ送信し、カレンダー登録が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)