### PR TITLE
fix: CalendarFunction と LineStateMachine の循環依存を解消

### DIFF
--- a/infra/sam/template.yaml
+++ b/infra/sam/template.yaml
@@ -44,7 +44,7 @@ Resources:
         Variables:
           APP_ENV: prod
           SSM_DOTENV_PARAMETER: !Ref SsmDotenvParameter
-          LINE_SM_ARN: !Ref LineStateMachine
+          LINE_SM_ARN: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${ProjectName}-line-sm"
       Policies:
         - AWSLambdaBasicExecutionRole
         - Statement:
@@ -74,7 +74,7 @@ Resources:
         - Statement:
             Effect: Allow
             Action: "states:StartExecution"
-            Resource: !Ref LineStateMachine
+            Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${ProjectName}-line-sm"
       Events:
         ApiRoot:
           Type: Api


### PR DESCRIPTION
## Summary

- `!Ref LineStateMachine` を `!Sub` による ARN 直接構築に変更し、CloudFormation の循環依存エラーを解消
- 前 PR #12 の SAM deploy が `Circular dependency between resources` で失敗したための修正

## 原因

`CalendarFunction`（Lambda）が `!Ref LineStateMachine` で SFN を参照し、`LineStateMachine` が HTTP Task 経由で API Gateway → `CalendarFunction` を参照するため、CloudFormation が依存解決できなかった。

## 修正

SFN 名は `${ProjectName}-line-sm` で固定のため、ARN を直接 `!Sub` で構築:

```yaml
# 変更前
LINE_SM_ARN: !Ref LineStateMachine
Resource: !Ref LineStateMachine

# 変更後
LINE_SM_ARN: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${ProjectName}-line-sm"
Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${ProjectName}-line-sm"
```

## Test plan

- [ ] CI（lint / test / typecheck）GREEN
- [ ] SAM deploy 成功（CloudFormation changeset が FAILED にならないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)