### PR TITLE
fix: 画像抽出で system prompt が未設定だった問題を修正

### DIFF
--- a/app/src/calendar_auto_register/clients/bedrock_client.py
+++ b/app/src/calendar_auto_register/clients/bedrock_client.py
@@ -57,6 +57,7 @@ def invoke_model_with_image(
     model_id: str,
     image_bytes: bytes,
     prompt: str,
+    system: str | None = None,
     media_type: str = "image/jpeg",
     max_tokens: int = 4096,
 ) -> dict[str, Any]:
@@ -82,7 +83,7 @@ def invoke_model_with_image(
     import base64
 
     image_base64 = base64.b64encode(image_bytes).decode("utf-8")
-    body = json.dumps({
+    request: dict[str, Any] = {
         "anthropic_version": "bedrock-2023-05-31",
         "max_tokens": max_tokens,
         "messages": [
@@ -104,7 +105,10 @@ def invoke_model_with_image(
                 ],
             }
         ],
-    }).encode("utf-8")
+    }
+    if system:
+        request["system"] = system
+    body = json.dumps(request).encode("utf-8")
 
     return invoke_model(
         region=region,

--- a/app/src/calendar_auto_register/features/llm_extract/usecase_llm_extract.py
+++ b/app/src/calendar_auto_register/features/llm_extract/usecase_llm_extract.py
@@ -362,7 +362,8 @@ def extract_events_from_image(
             region=settings.region,
             model_id=vision_model_id,
             image_bytes=image_bytes,
-            prompt=CALENDAR_EVENT_EXTRACTION_SYSTEM,
+            system=CALENDAR_EVENT_EXTRACTION_SYSTEM,
+            prompt="この画像からカレンダーの予定情報を抽出してください。",
         )
         events = _parse_image_llm_response(response)
         # [D4] テキストパスと同一の正規化を適用


### PR DESCRIPTION
## Summary

- `invoke_model_with_image()` で `CALENDAR_EVENT_EXTRACTION_SYSTEM` がユーザーメッセージのテキストとして送られており、system prompt が未設定だった
- 「あなたは日本語のメール本文から予定情報を抽出し…」という指示が画像解析時にユーザーターンで渡されていたため、LLM が正しく動作できず `events: []` を返していた

## 変更内容

- `bedrock_client.py`: `invoke_model_with_image()` に `system` パラメータを追加し Bedrock リクエストの `system` フィールドに渡す
- `usecase_llm_extract.py`: `CALENDAR_EVENT_EXTRACTION_SYSTEM` を `system` に移動し、ユーザーメッセージを画像専用の簡潔な指示に変更

## Test plan

- [x] `uv run pytest` 81テスト全 PASSED
- [ ] LINE から画像を送信してカレンダーへの登録を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)